### PR TITLE
Added Custome Drop event

### DIFF
--- a/src/main/java/us/thezircon/play/autopickup/events/AutoPickUpEvent.java
+++ b/src/main/java/us/thezircon/play/autopickup/events/AutoPickUpEvent.java
@@ -1,0 +1,19 @@
+package us.thezircon.play.autopickup.events;
+
+import org.bukkit.entity.Player;
+import us.thezircon.play.autopickup.utils.events.CancellableEvent;
+
+import javax.annotation.Nullable;
+
+public class AutoPickUpEvent extends CancellableEvent {
+
+    private final @Nullable Player player;
+
+    public AutoPickUpEvent(@Nullable Player player) {
+        this.player = player;
+    }
+
+    public @Nullable Player getPlayer() {
+        return player;
+    }
+}

--- a/src/main/java/us/thezircon/play/autopickup/listeners/BlockBreakEventListener.java
+++ b/src/main/java/us/thezircon/play/autopickup/listeners/BlockBreakEventListener.java
@@ -19,6 +19,7 @@ import org.bukkit.inventory.meta.Damageable;
 import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.scheduler.BukkitRunnable;
 import us.thezircon.play.autopickup.AutoPickup;
+import us.thezircon.play.autopickup.events.AutoPickUpEvent;
 import us.thezircon.play.autopickup.utils.HexFormat;
 import us.thezircon.play.autopickup.utils.Mendable;
 import us.thezircon.play.autopickup.utils.PickupObjective;
@@ -144,6 +145,13 @@ public class BlockBreakEventListener implements Listener {
                 }
             }
         }.runTaskLater(PLUGIN, 1);
+
+        // Call event and check for cancel
+        AutoPickUpEvent autoPickUpEvent = new AutoPickUpEvent(player);
+        autoPickUpEvent.call();
+
+        if (autoPickUpEvent.isCancelled())
+            return;
 
         // Mend Items & Give Player XP
         int xp = e.getExpToDrop();

--- a/src/main/java/us/thezircon/play/autopickup/listeners/BlockDropItemEventListener.java
+++ b/src/main/java/us/thezircon/play/autopickup/listeners/BlockDropItemEventListener.java
@@ -10,6 +10,7 @@ import org.bukkit.event.Listener;
 import org.bukkit.event.block.BlockDropItemEvent;
 import org.bukkit.inventory.ItemStack;
 import us.thezircon.play.autopickup.AutoPickup;
+import us.thezircon.play.autopickup.events.AutoPickUpEvent;
 import us.thezircon.play.autopickup.utils.AutoSmelt;
 import us.thezircon.play.autopickup.utils.HexFormat;
 
@@ -43,6 +44,14 @@ public class BlockDropItemEventListener implements Listener {
         if (AutoPickup.worldsBlacklist!=null && AutoPickup.worldsBlacklist.contains(loc.getWorld().getName())) {
             return;
         }
+
+        // Call event and check for cancel
+        AutoPickUpEvent autoPickUpEvent = new AutoPickUpEvent(player);
+        autoPickUpEvent.call();
+
+        if (autoPickUpEvent.isCancelled())
+            return;
+
 
 //        if (block.getState() instanceof Container) {
 //            return; // Containers are handled in block break event

--- a/src/main/java/us/thezircon/play/autopickup/listeners/EntityDeathEventListener.java
+++ b/src/main/java/us/thezircon/play/autopickup/listeners/EntityDeathEventListener.java
@@ -10,6 +10,7 @@ import org.bukkit.event.Listener;
 import org.bukkit.event.entity.EntityDeathEvent;
 import org.bukkit.inventory.ItemStack;
 import us.thezircon.play.autopickup.AutoPickup;
+import us.thezircon.play.autopickup.events.AutoPickUpEvent;
 
 import java.util.HashMap;
 import java.util.Iterator;
@@ -62,6 +63,12 @@ public class EntityDeathEventListener implements Listener {
             }
         }
 
+        // Call event and check for cancel
+        AutoPickUpEvent autoPickUpEvent = new AutoPickUpEvent(player);
+        autoPickUpEvent.call();
+
+        if (autoPickUpEvent.isCancelled())
+            return;
 
 
         // Mend Items & Give Player XP

--- a/src/main/java/us/thezircon/play/autopickup/listeners/EntityDropItemEventListener.java
+++ b/src/main/java/us/thezircon/play/autopickup/listeners/EntityDropItemEventListener.java
@@ -8,6 +8,7 @@ import org.bukkit.event.entity.EntityDropItemEvent;
 import org.bukkit.event.player.PlayerShearEntityEvent;
 import org.bukkit.inventory.ItemStack;
 import us.thezircon.play.autopickup.AutoPickup;
+import us.thezircon.play.autopickup.events.AutoPickUpEvent;
 
 import java.util.HashMap;
 import java.util.Iterator;
@@ -32,6 +33,13 @@ public class EntityDropItemEventListener implements Listener {
         if (AutoPickup.worldsBlacklist!=null && AutoPickup.worldsBlacklist.contains(e.getEntity().getWorld().getName())) {
             return;
         }
+
+        // Call event and check for cancel
+        AutoPickUpEvent autoPickUpEvent = new AutoPickUpEvent(null);
+        autoPickUpEvent.call();
+
+        if (autoPickUpEvent.isCancelled())
+            return;
 
         UUID sheep = e.getEntity().getUniqueId();
         if (player_sheep_map.containsKey(sheep)) {

--- a/src/main/java/us/thezircon/play/autopickup/listeners/MythicMobListener.java
+++ b/src/main/java/us/thezircon/play/autopickup/listeners/MythicMobListener.java
@@ -9,6 +9,7 @@ import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.inventory.ItemStack;
 import us.thezircon.play.autopickup.AutoPickup;
+import us.thezircon.play.autopickup.events.AutoPickUpEvent;
 
 import java.util.HashMap;
 import java.util.Iterator;
@@ -51,6 +52,13 @@ public class MythicMobListener implements Listener {
                 return;
             }
         }
+
+        // Call event and check for cancel
+        AutoPickUpEvent autoPickUpEvent = new AutoPickUpEvent(player);
+        autoPickUpEvent.call();
+
+        if (autoPickUpEvent.isCancelled())
+            return;
 
 
         // Drops

--- a/src/main/java/us/thezircon/play/autopickup/listeners/PlayerInteractEventListener.java
+++ b/src/main/java/us/thezircon/play/autopickup/listeners/PlayerInteractEventListener.java
@@ -13,6 +13,7 @@ import org.bukkit.event.player.PlayerInteractEvent;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.scheduler.BukkitRunnable;
 import us.thezircon.play.autopickup.AutoPickup;
+import us.thezircon.play.autopickup.events.AutoPickUpEvent;
 
 import java.util.HashMap;
 
@@ -37,6 +38,13 @@ public class PlayerInteractEventListener implements Listener {
         if (AutoPickup.worldsBlacklist!=null && AutoPickup.worldsBlacklist.contains(loc.getWorld().getName())) {
             return;
         }
+
+        // Call event and check for cancel
+        AutoPickUpEvent autoPickUpEvent = new AutoPickUpEvent(player);
+        autoPickUpEvent.call();
+
+        if (autoPickUpEvent.isCancelled())
+            return;
 
         if(e.getAction() == Action.RIGHT_CLICK_BLOCK) {
             if(e.getClickedBlock().getType() == Material.SWEET_BERRY_BUSH) {

--- a/src/main/java/us/thezircon/play/autopickup/utils/events/CallableEvent.java
+++ b/src/main/java/us/thezircon/play/autopickup/utils/events/CallableEvent.java
@@ -1,0 +1,27 @@
+package us.thezircon.play.autopickup.utils.events;
+
+import org.bukkit.Bukkit;
+import org.bukkit.event.Event;
+import org.bukkit.event.HandlerList;
+
+public class CallableEvent extends Event {
+    private static final HandlerList handlers = new HandlerList();
+
+    private boolean isCalled = false;
+
+    public static HandlerList getHandlerList() {
+        return handlers;
+    }
+
+    public CallableEvent call() {
+        if (!this.isCalled) {
+            Bukkit.getPluginManager().callEvent(this);
+            this.isCalled = true;
+        }
+        return this;
+    }
+
+    public HandlerList getHandlers() {
+        return handlers;
+    }
+}

--- a/src/main/java/us/thezircon/play/autopickup/utils/events/CancellableEvent.java
+++ b/src/main/java/us/thezircon/play/autopickup/utils/events/CancellableEvent.java
@@ -1,0 +1,26 @@
+package us.thezircon.play.autopickup.utils.events;
+
+import org.bukkit.event.Cancellable;
+import org.bukkit.event.HandlerList;
+
+public class CancellableEvent extends CallableEvent implements Cancellable {
+    private static final HandlerList handlers = new HandlerList();
+
+    private boolean isCancelled = false;
+
+    public static HandlerList getHandlerList() {
+        return handlers;
+    }
+
+    public HandlerList getHandlers() {
+        return handlers;
+    }
+
+    public boolean isCancelled() {
+        return this.isCancelled;
+    }
+
+    public void setCancelled(boolean b) {
+        this.isCancelled = b;
+    }
+}


### PR DESCRIPTION
### Feature:
Added a custom spigot event in which a developer can listen to when hooking into the plugin. This allows the developer to cancel the auto-pickup event.

### Why?
I made this for my personal project as I had to hook into the auto-pickup plugin and sometimes cancel the event. I made this pull request in case others might also need to do this in the future. 

