### PR TITLE
Feature: Add Folia Support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,6 @@
                             <goal>shade</goal>
                         </goals>
                         <configuration>
-                            <minimizeJar>true</minimizeJar>
                             <relocations>
                                 <relocation>
                                     <pattern>com.tcoded.folialib</pattern>

--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>3.1.0</version>
+                <version>3.6.0</version>
                 <executions>
                     <execution>
                         <phase>package</phase>
@@ -41,6 +41,12 @@
                         </goals>
                         <configuration>
                             <minimizeJar>true</minimizeJar>
+                            <relocations>
+                                <relocation>
+                                    <pattern>com.tcoded.folialib</pattern>
+                                    <shadedPattern>us.thezircon.play.autopickup.lib.folialib</shadedPattern>
+                                </relocation>
+                            </relocations>
                         </configuration>
                     </execution>
                 </executions>
@@ -76,7 +82,10 @@
             <name>Lumine Releases</name>
             <url>https://mvn.lumine.io/repository/maven-public/</url>
         </repository>
-
+        <repository>
+            <id>jitpack</id>
+            <url>https://jitpack.io</url>
+        </repository>
     </repositories>
 
     <dependencies>
@@ -95,7 +104,7 @@
         <dependency>
             <groupId>org.jetbrains</groupId>
             <artifactId>annotations</artifactId>
-            <version>20.1.0</version>
+            <version>26.0.1</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -109,6 +118,12 @@
             <artifactId>Mythic-Dist</artifactId>
             <version>5.6.1</version>
             <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.github.technicallycoded</groupId>
+            <artifactId>FoliaLib</artifactId>
+            <version>0.4.3</version>
+            <scope>compile</scope>
         </dependency>
     </dependencies>
 </project>

--- a/src/main/java/us/thezircon/play/autopickup/listeners/EntityDeathEventListener.java
+++ b/src/main/java/us/thezircon/play/autopickup/listeners/EntityDeathEventListener.java
@@ -1,6 +1,5 @@
 package us.thezircon.play.autopickup.listeners;
 
-import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Player;
@@ -33,16 +32,13 @@ public class EntityDeathEventListener implements Listener {
 
         if (!PLUGIN.autopickup_list_mobs.contains(player)) return;
 
-        Bukkit.getScheduler().runTaskAsynchronously(PLUGIN, new Runnable() {
-            @Override
-            public void run() {
-                boolean requirePermsAUTO = PLUGIN.getConfig().getBoolean("requirePerms.autopickup");
-                if (!requirePermsAUTO) {
-                    return;
-                }
-                if (!player.hasPermission("autopickup.pickup.entities") && !player.hasPermission("autopickup.pickup.entities.autoenabled")) {
-                    PLUGIN.autopickup_list_mobs.remove(player);
-                }
+        AutoPickup.getFoliaLib().getScheduler().runAsync(task -> {
+            boolean requirePermsAUTO = PLUGIN.getConfig().getBoolean("requirePerms.autopickup");
+            if (!requirePermsAUTO) {
+                return;
+            }
+            if (!player.hasPermission("autopickup.pickup.entities") && !player.hasPermission("autopickup.pickup.entities.autoenabled")) {
+                PLUGIN.autopickup_list_mobs.remove(player);
             }
         });
 

--- a/src/main/java/us/thezircon/play/autopickup/listeners/EntityDropItemEventListener.java
+++ b/src/main/java/us/thezircon/play/autopickup/listeners/EntityDropItemEventListener.java
@@ -63,12 +63,9 @@ public class EntityDropItemEventListener implements Listener {
                 }
             }
 
-            Bukkit.getScheduler().runTaskAsynchronously(PLUGIN, new Runnable() {
-                @Override
-                public void run() {
-                    if (!player.hasPermission("autopickup.pickup.mined")) {
-                        PLUGIN.autopickup_list.remove(player);
-                    }
+            AutoPickup.getFoliaLib().getScheduler().runAsync(task -> {
+                if (!player.hasPermission("autopickup.pickup.mined")) {
+                    PLUGIN.autopickup_list.remove(player);
                 }
             });
         }

--- a/src/main/java/us/thezircon/play/autopickup/listeners/PlayerInteractEventListener.java
+++ b/src/main/java/us/thezircon/play/autopickup/listeners/PlayerInteractEventListener.java
@@ -11,7 +11,6 @@ import org.bukkit.event.Listener;
 import org.bukkit.event.block.Action;
 import org.bukkit.event.player.PlayerInteractEvent;
 import org.bukkit.inventory.ItemStack;
-import org.bukkit.scheduler.BukkitRunnable;
 import us.thezircon.play.autopickup.AutoPickup;
 
 import java.util.HashMap;
@@ -40,10 +39,9 @@ public class PlayerInteractEventListener implements Listener {
 
         if(e.getAction() == Action.RIGHT_CLICK_BLOCK) {
             if(e.getClickedBlock().getType() == Material.SWEET_BERRY_BUSH) {
-                new BukkitRunnable() {
-                    @Override
-                    public void run() {
-                        for (Entity entity : loc.getWorld().getNearbyEntities(loc, 1, 1, 1)) {
+                AutoPickup.getFoliaLib().getScheduler().runAtLocationLater(loc, () -> {
+                    for (Entity entity : loc.getWorld().getNearbyEntities(loc, 1, 1, 1)) {
+                        AutoPickup.getFoliaLib().getScheduler().runAtEntity(entity, task -> {
                             if (entity.getType().equals(EntityType.DROPPED_ITEM)) {
                                 Item item = (Item) entity;
                                 ItemStack items = item.getItemStack();
@@ -64,9 +62,9 @@ public class PlayerInteractEventListener implements Listener {
                                 }
 
                             }
-                        }
+                        });
                     }
-                }.runTaskLater(PLUGIN, 1);
+                }, 1);
             }
         }
     }

--- a/src/main/java/us/thezircon/play/autopickup/utils/Metrics.java
+++ b/src/main/java/us/thezircon/play/autopickup/utils/Metrics.java
@@ -10,6 +10,7 @@ import org.bukkit.entity.Player;
 import org.bukkit.plugin.Plugin;
 import org.bukkit.plugin.RegisteredServiceProvider;
 import org.bukkit.plugin.ServicePriority;
+import us.thezircon.play.autopickup.AutoPickup;
 
 import javax.net.ssl.HttpsURLConnection;
 import java.io.*;
@@ -180,7 +181,7 @@ public class Metrics {
                 }
                 // Nevertheless we want our code to run in the Bukkit main thread, so we have to use the Bukkit scheduler
                 // Don't be afraid! The connection to the bStats server is still async, only the stats collection is sync ;)
-                Bukkit.getScheduler().runTask(plugin, () -> submitData());
+                AutoPickup.getFoliaLib().getScheduler().runNextTick(task -> submitData());
             }
         }, 1000 * 60 * 5, 1000 * 60 * 30);
         // Submit the data every 30 minutes, first time after 5 minutes to give other plugins enough time to start

--- a/src/main/java/us/thezircon/play/autopickup/utils/PickupPlayer.java
+++ b/src/main/java/us/thezircon/play/autopickup/utils/PickupPlayer.java
@@ -3,7 +3,6 @@ package us.thezircon.play.autopickup.utils;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.configuration.file.YamlConfiguration;
 import org.bukkit.entity.Player;
-import org.bukkit.scheduler.BukkitRunnable;
 import us.thezircon.play.autopickup.AutoPickup;
 
 import java.io.File;
@@ -51,63 +50,54 @@ public class PickupPlayer {
     }
 
     public void setEnabled(boolean e) {
-        new BukkitRunnable() {
-            @Override
-            public void run() {
-                if (!fileExists()) {createFile();}
+        AutoPickup.getFoliaLib().getScheduler().runLater(() -> {
+            if (!fileExists()) {createFile();}
 
-                File playerFile = new File(plugin.getDataFolder()+File.separator+"PlayerData"+File.separator+uuid+".yml");
-                FileConfiguration data = YamlConfiguration.loadConfiguration(playerFile);
+            File playerFile = new File(plugin.getDataFolder()+File.separator+"PlayerData"+File.separator+uuid+".yml");
+            FileConfiguration data = YamlConfiguration.loadConfiguration(playerFile);
 
-                data.set("enabled", e);
+            data.set("enabled", e);
 
-                try {
-                    data.save(playerFile);
-                } catch (IOException err){
-                    log.warning("[AutoPickup] Unable to update "+uuid+"'s data file.");
-                }
+            try {
+                data.save(playerFile);
+            } catch (IOException err){
+                log.warning("[AutoPickup] Unable to update "+uuid+"'s data file.");
             }
-        }.runTaskLater(plugin, 1);
+        }, 1);
     }
 
     public void setEnabledEntities(boolean e) {
-        new BukkitRunnable() {
-            @Override
-            public void run() {
-                if (!fileExists()) {createFile();}
+        AutoPickup.getFoliaLib().getScheduler().runLater(() -> {
+            if (!fileExists()) {createFile();}
 
-                File playerFile = new File(plugin.getDataFolder()+File.separator+"PlayerData"+File.separator+uuid+".yml");
-                FileConfiguration data = YamlConfiguration.loadConfiguration(playerFile);
+            File playerFile = new File(plugin.getDataFolder()+File.separator+"PlayerData"+File.separator+uuid+".yml");
+            FileConfiguration data = YamlConfiguration.loadConfiguration(playerFile);
 
-                data.set("enabled_mob_drops", e);
+            data.set("enabled_mob_drops", e);
 
-                try {
-                    data.save(playerFile);
-                } catch (IOException err){
-                    log.warning("[AutoPickup] Unable to update "+uuid+"'s data file.");
-                }
+            try {
+                data.save(playerFile);
+            } catch (IOException err){
+                log.warning("[AutoPickup] Unable to update "+uuid+"'s data file.");
             }
-        }.runTaskLater(plugin, 1);
+        }, 1);
     }
 
     public void setEnabledAutoSmelt(boolean e) {
-        new BukkitRunnable() {
-            @Override
-            public void run() {
-                if (!fileExists()) {createFile();}
+        AutoPickup.getFoliaLib().getScheduler().runLater(() -> {
+            if (!fileExists()) {createFile();}
 
-                File playerFile = new File(plugin.getDataFolder()+File.separator+"PlayerData"+File.separator+uuid+".yml");
-                FileConfiguration data = YamlConfiguration.loadConfiguration(playerFile);
+            File playerFile = new File(plugin.getDataFolder()+File.separator+"PlayerData"+File.separator+uuid+".yml");
+            FileConfiguration data = YamlConfiguration.loadConfiguration(playerFile);
 
-                data.set("enabled_auto_smelt", e);
+            data.set("enabled_auto_smelt", e);
 
-                try {
-                    data.save(playerFile);
-                } catch (IOException err){
-                    log.warning("[AutoPickup] Unable to update "+uuid+"'s data file.");
-                }
+            try {
+                data.save(playerFile);
+            } catch (IOException err){
+                log.warning("[AutoPickup] Unable to update "+uuid+"'s data file.");
             }
-        }.runTaskLater(plugin, 1);
+        }, 1);
     }
 
     public boolean getToggle(){

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -6,6 +6,7 @@ authors: [BUTTERFIELD8]
 description: Automatically pickup broken blocks.
 website: https://discord.gg/ncHH4FP
 api-version: 1.13
+folia-supported: true
 softdepend: [BentoBox, LockettePro, UpgradeableHoppers, PlaceholderAPI, Jobs, MythicMobs]
 commands:
   autopickup:


### PR DESCRIPTION
This PR introduces a library called [FoliaLib](https://github.com/TechnicallyCoded/FoliaLib) that allows this plugin to run on both Folia and Spigot/Paper. This library includes methods to replace scheduling calls.

Code has been tested with Paper 1.21.1 and Folia 1.21.4
