### PR TITLE
Fix support for vertical breaking

### DIFF
--- a/src/main/java/us/thezircon/play/autopickup/listeners/BlockBreakEventListener.java
+++ b/src/main/java/us/thezircon/play/autopickup/listeners/BlockBreakEventListener.java
@@ -337,6 +337,20 @@ public class BlockBreakEventListener implements Listener {
             addLocation(lnew, e.getPlayer());
         }
 
+        //deal with glow berries
+        if (e.getBlock().getType() == Material.CAVE_VINES_PLANT || e.getBlock().getRelative(BlockFace.DOWN).getType() == Material.CAVE_VINES_PLANT) {
+            Location lnew = l.clone();
+            do {
+                lnew.setY(lnew.getY() - 1);
+                if (lnew.getBlock().getType() == Material.CAVE_VINES_PLANT) {
+                    addLocation(lnew, e.getPlayer());
+                } else {
+                    break;
+                }
+            } while (true);
+            addLocation(lnew, e.getPlayer());
+        }
+
         // TEST END
 
         if (verticalReq.contains(e.getBlock().getType()) || verticalReqDown.contains(e.getBlock().getType())) {

--- a/src/main/java/us/thezircon/play/autopickup/listeners/BlockBreakEventListener.java
+++ b/src/main/java/us/thezircon/play/autopickup/listeners/BlockBreakEventListener.java
@@ -337,63 +337,71 @@ public class BlockBreakEventListener implements Listener {
             addLocation(lnew, e.getPlayer());
         }
 
-        //deal with glow berries
-        if (e.getBlock().getType() == Material.CAVE_VINES_PLANT || e.getBlock().getRelative(BlockFace.DOWN).getType() == Material.CAVE_VINES_PLANT) {
-            Location lnew = l.clone();
-            do {
-                lnew.setY(lnew.getY() - 1);
-                if (lnew.getBlock().getType() == Material.CAVE_VINES_PLANT) {
-                    addLocation(lnew, e.getPlayer());
-                } else {
-                    break;
-                }
-            } while (true);
-            addLocation(lnew, e.getPlayer());
-        }else if (e.getBlock().getType() == Material.CAVE_VINES || e.getBlock().getRelative(BlockFace.DOWN).getType() == Material.CAVE_VINES) {
-            Location lnew = l.clone();
-            do {
-                lnew.setY(lnew.getY() - 1);
-                if (lnew.getBlock().getType() == Material.CAVE_VINES) {
-                    addLocation(lnew, e.getPlayer());
-                } else {
-                    break;
-                }
-            } while (true);
-            addLocation(lnew, e.getPlayer());
-        }
-
-        //deal with dripleafs
-        if (e.getBlock().getType() == Material.BIG_DRIPLEAF_STEM || e.getBlock().getRelative(BlockFace.UP).getType() == Material.BIG_DRIPLEAF_STEM ) {
-            Location lnew = l.clone();
-            double y = lnew.getY();
-            do {
-                lnew.setY(lnew.getY() + 1);
-                if (lnew.getBlock().getType() == Material.BIG_DRIPLEAF_STEM) {
-                    addLocation(lnew, e.getPlayer());
-                }else if (lnew.getBlock().getType() == Material.BIG_DRIPLEAF) {
-                    addLocation(lnew, e.getPlayer());
-                }else {
-                    y--;
-                    lnew.setY(y);
-                    if (lnew.getBlock().getType() == Material.BIG_DRIPLEAF_STEM) {
+        if (
+                Bukkit.getVersion().contains("1.17") ||
+                Bukkit.getVersion().contains("1.18") ||
+                Bukkit.getVersion().contains("1.19") ||
+                Bukkit.getVersion().contains("1.20") ||
+                Bukkit.getVersion().contains("1.21")
+        ) {
+            //deal with glow berries
+            if (e.getBlock().getType() == Material.CAVE_VINES_PLANT || e.getBlock().getRelative(BlockFace.DOWN).getType() == Material.CAVE_VINES_PLANT) {
+                Location lnew = l.clone();
+                do {
+                    lnew.setY(lnew.getY() - 1);
+                    if (lnew.getBlock().getType() == Material.CAVE_VINES_PLANT) {
                         addLocation(lnew, e.getPlayer());
-                    }else {
+                    } else {
                         break;
                     }
-                }
-            } while (true);
-            addLocation(lnew, e.getPlayer());
-        }else if (e.getBlock().getType() == Material.BIG_DRIPLEAF || e.getBlock().getRelative(BlockFace.UP).getType() == Material.BIG_DRIPLEAF) {
-            Location lnew = l.clone();
-            do {
-                lnew.setY(lnew.getY() - 1);
-                if (lnew.getBlock().getType() == Material.BIG_DRIPLEAF) {
-                    addLocation(lnew, e.getPlayer());
-                } else {
-                    break;
-                }
-            } while (true);
-            addLocation(lnew, e.getPlayer());
+                } while (true);
+                addLocation(lnew, e.getPlayer());
+            } else if (e.getBlock().getType() == Material.CAVE_VINES || e.getBlock().getRelative(BlockFace.DOWN).getType() == Material.CAVE_VINES) {
+                Location lnew = l.clone();
+                do {
+                    lnew.setY(lnew.getY() - 1);
+                    if (lnew.getBlock().getType() == Material.CAVE_VINES) {
+                        addLocation(lnew, e.getPlayer());
+                    } else {
+                        break;
+                    }
+                } while (true);
+                addLocation(lnew, e.getPlayer());
+            }
+
+            //deal with dripleafs
+            if (e.getBlock().getType() == Material.BIG_DRIPLEAF_STEM || e.getBlock().getRelative(BlockFace.UP).getType() == Material.BIG_DRIPLEAF_STEM) {
+                Location lnew = l.clone();
+                double y = lnew.getY();
+                do {
+                    lnew.setY(lnew.getY() + 1);
+                    if (lnew.getBlock().getType() == Material.BIG_DRIPLEAF_STEM) {
+                        addLocation(lnew, e.getPlayer());
+                    } else if (lnew.getBlock().getType() == Material.BIG_DRIPLEAF) {
+                        addLocation(lnew, e.getPlayer());
+                    } else {
+                        y--;
+                        lnew.setY(y);
+                        if (lnew.getBlock().getType() == Material.BIG_DRIPLEAF_STEM) {
+                            addLocation(lnew, e.getPlayer());
+                        } else {
+                            break;
+                        }
+                    }
+                } while (true);
+                addLocation(lnew, e.getPlayer());
+            } else if (e.getBlock().getType() == Material.BIG_DRIPLEAF || e.getBlock().getRelative(BlockFace.UP).getType() == Material.BIG_DRIPLEAF) {
+                Location lnew = l.clone();
+                do {
+                    lnew.setY(lnew.getY() - 1);
+                    if (lnew.getBlock().getType() == Material.BIG_DRIPLEAF) {
+                        addLocation(lnew, e.getPlayer());
+                    } else {
+                        break;
+                    }
+                } while (true);
+                addLocation(lnew, e.getPlayer());
+            }
         }
 
         // TEST END

--- a/src/main/java/us/thezircon/play/autopickup/listeners/BlockBreakEventListener.java
+++ b/src/main/java/us/thezircon/play/autopickup/listeners/BlockBreakEventListener.java
@@ -338,29 +338,30 @@ public class BlockBreakEventListener implements Listener {
         }
 
         if (
+                Bukkit.getVersion().contains("1.16") ||
                 Bukkit.getVersion().contains("1.17") ||
                 Bukkit.getVersion().contains("1.18") ||
                 Bukkit.getVersion().contains("1.19") ||
                 Bukkit.getVersion().contains("1.20") ||
                 Bukkit.getVersion().contains("1.21")
         ) {
-            //deal with glow berries
-            if (e.getBlock().getType() == Material.CAVE_VINES_PLANT || e.getBlock().getRelative(BlockFace.DOWN).getType() == Material.CAVE_VINES_PLANT) {
+            //deal with weeping vines
+            if (e.getBlock().getType() == Material.WEEPING_VINES_PLANT || e.getBlock().getRelative(BlockFace.DOWN).getType() == Material.WEEPING_VINES_PLANT) {
                 Location lnew = l.clone();
                 do {
                     lnew.setY(lnew.getY() - 1);
-                    if (lnew.getBlock().getType() == Material.CAVE_VINES_PLANT) {
+                    if (lnew.getBlock().getType() == Material.WEEPING_VINES_PLANT) {
                         addLocation(lnew, e.getPlayer());
                     } else {
                         break;
                     }
                 } while (true);
                 addLocation(lnew, e.getPlayer());
-            } else if (e.getBlock().getType() == Material.CAVE_VINES || e.getBlock().getRelative(BlockFace.DOWN).getType() == Material.CAVE_VINES) {
+            } else if (e.getBlock().getType() == Material.WEEPING_VINES || e.getBlock().getRelative(BlockFace.DOWN).getType() == Material.WEEPING_VINES) {
                 Location lnew = l.clone();
                 do {
                     lnew.setY(lnew.getY() - 1);
-                    if (lnew.getBlock().getType() == Material.CAVE_VINES) {
+                    if (lnew.getBlock().getType() == Material.WEEPING_VINES) {
                         addLocation(lnew, e.getPlayer());
                     } else {
                         break;
@@ -369,38 +370,90 @@ public class BlockBreakEventListener implements Listener {
                 addLocation(lnew, e.getPlayer());
             }
 
-            //deal with dripleafs
-            if (e.getBlock().getType() == Material.BIG_DRIPLEAF_STEM || e.getBlock().getRelative(BlockFace.UP).getType() == Material.BIG_DRIPLEAF_STEM) {
+            //deal with twisting vines
+            if (e.getBlock().getType() == Material.TWISTING_VINES_PLANT || e.getBlock().getRelative(BlockFace.UP).getType() == Material.TWISTING_VINES_PLANT) {
                 Location lnew = l.clone();
-                double y = lnew.getY();
                 do {
                     lnew.setY(lnew.getY() + 1);
-                    if (lnew.getBlock().getType() == Material.BIG_DRIPLEAF_STEM) {
-                        addLocation(lnew, e.getPlayer());
-                    } else if (lnew.getBlock().getType() == Material.BIG_DRIPLEAF) {
-                        addLocation(lnew, e.getPlayer());
-                    } else {
-                        y--;
-                        lnew.setY(y);
-                        if (lnew.getBlock().getType() == Material.BIG_DRIPLEAF_STEM) {
-                            addLocation(lnew, e.getPlayer());
-                        } else {
-                            break;
-                        }
-                    }
-                } while (true);
-                addLocation(lnew, e.getPlayer());
-            } else if (e.getBlock().getType() == Material.BIG_DRIPLEAF || e.getBlock().getRelative(BlockFace.UP).getType() == Material.BIG_DRIPLEAF) {
-                Location lnew = l.clone();
-                do {
-                    lnew.setY(lnew.getY() - 1);
-                    if (lnew.getBlock().getType() == Material.BIG_DRIPLEAF) {
+                    if (lnew.getBlock().getType() == Material.TWISTING_VINES_PLANT) {
                         addLocation(lnew, e.getPlayer());
                     } else {
                         break;
                     }
                 } while (true);
                 addLocation(lnew, e.getPlayer());
+            } else if (e.getBlock().getType() == Material.TWISTING_VINES || e.getBlock().getRelative(BlockFace.UP).getType() == Material.TWISTING_VINES) {
+                Location lnew = l.clone();
+                do {
+                    lnew.setY(lnew.getY() + 1);
+                    if (lnew.getBlock().getType() == Material.TWISTING_VINES) {
+                        addLocation(lnew, e.getPlayer());
+                    } else {
+                        break;
+                    }
+                } while (true);
+                addLocation(lnew, e.getPlayer());
+            }
+
+            if(!Bukkit.getVersion().contains("1.16")) {
+                //deal with glow berries
+                if (e.getBlock().getType() == Material.CAVE_VINES_PLANT || e.getBlock().getRelative(BlockFace.DOWN).getType() == Material.CAVE_VINES_PLANT) {
+                    Location lnew = l.clone();
+                    do {
+                        lnew.setY(lnew.getY() - 1);
+                        if (lnew.getBlock().getType() == Material.CAVE_VINES_PLANT) {
+                            addLocation(lnew, e.getPlayer());
+                        } else {
+                            break;
+                        }
+                    } while (true);
+                    addLocation(lnew, e.getPlayer());
+                } else if (e.getBlock().getType() == Material.CAVE_VINES || e.getBlock().getRelative(BlockFace.DOWN).getType() == Material.CAVE_VINES) {
+                    Location lnew = l.clone();
+                    do {
+                        lnew.setY(lnew.getY() - 1);
+                        if (lnew.getBlock().getType() == Material.CAVE_VINES) {
+                            addLocation(lnew, e.getPlayer());
+                        } else {
+                            break;
+                        }
+                    } while (true);
+                    addLocation(lnew, e.getPlayer());
+                }
+
+                //deal with dripleafs
+                if (e.getBlock().getType() == Material.BIG_DRIPLEAF_STEM || e.getBlock().getRelative(BlockFace.UP).getType() == Material.BIG_DRIPLEAF_STEM) {
+                    Location lnew = l.clone();
+                    double y = lnew.getY();
+                    do {
+                        lnew.setY(lnew.getY() + 1);
+                        if (lnew.getBlock().getType() == Material.BIG_DRIPLEAF_STEM) {
+                            addLocation(lnew, e.getPlayer());
+                        } else if (lnew.getBlock().getType() == Material.BIG_DRIPLEAF) {
+                            addLocation(lnew, e.getPlayer());
+                        } else {
+                            y--;
+                            lnew.setY(y);
+                            if (lnew.getBlock().getType() == Material.BIG_DRIPLEAF_STEM) {
+                                addLocation(lnew, e.getPlayer());
+                            } else {
+                                break;
+                            }
+                        }
+                    } while (true);
+                    addLocation(lnew, e.getPlayer());
+                } else if (e.getBlock().getType() == Material.BIG_DRIPLEAF || e.getBlock().getRelative(BlockFace.UP).getType() == Material.BIG_DRIPLEAF) {
+                    Location lnew = l.clone();
+                    do {
+                        lnew.setY(lnew.getY() - 1);
+                        if (lnew.getBlock().getType() == Material.BIG_DRIPLEAF) {
+                            addLocation(lnew, e.getPlayer());
+                        } else {
+                            break;
+                        }
+                    } while (true);
+                    addLocation(lnew, e.getPlayer());
+                }
             }
         }
 

--- a/src/main/java/us/thezircon/play/autopickup/listeners/BlockBreakEventListener.java
+++ b/src/main/java/us/thezircon/play/autopickup/listeners/BlockBreakEventListener.java
@@ -349,6 +349,51 @@ public class BlockBreakEventListener implements Listener {
                 }
             } while (true);
             addLocation(lnew, e.getPlayer());
+        }else if (e.getBlock().getType() == Material.CAVE_VINES || e.getBlock().getRelative(BlockFace.DOWN).getType() == Material.CAVE_VINES) {
+            Location lnew = l.clone();
+            do {
+                lnew.setY(lnew.getY() - 1);
+                if (lnew.getBlock().getType() == Material.CAVE_VINES) {
+                    addLocation(lnew, e.getPlayer());
+                } else {
+                    break;
+                }
+            } while (true);
+            addLocation(lnew, e.getPlayer());
+        }
+
+        //deal with dripleafs
+        if (e.getBlock().getType() == Material.BIG_DRIPLEAF_STEM || e.getBlock().getRelative(BlockFace.UP).getType() == Material.BIG_DRIPLEAF_STEM ) {
+            Location lnew = l.clone();
+            double y = lnew.getY();
+            do {
+                lnew.setY(lnew.getY() + 1);
+                if (lnew.getBlock().getType() == Material.BIG_DRIPLEAF_STEM) {
+                    addLocation(lnew, e.getPlayer());
+                }else if (lnew.getBlock().getType() == Material.BIG_DRIPLEAF) {
+                    addLocation(lnew, e.getPlayer());
+                }else {
+                    y--;
+                    lnew.setY(y);
+                    if (lnew.getBlock().getType() == Material.BIG_DRIPLEAF_STEM) {
+                        addLocation(lnew, e.getPlayer());
+                    }else {
+                        break;
+                    }
+                }
+            } while (true);
+            addLocation(lnew, e.getPlayer());
+        }else if (e.getBlock().getType() == Material.BIG_DRIPLEAF || e.getBlock().getRelative(BlockFace.UP).getType() == Material.BIG_DRIPLEAF) {
+            Location lnew = l.clone();
+            do {
+                lnew.setY(lnew.getY() - 1);
+                if (lnew.getBlock().getType() == Material.BIG_DRIPLEAF) {
+                    addLocation(lnew, e.getPlayer());
+                } else {
+                    break;
+                }
+            } while (true);
+            addLocation(lnew, e.getPlayer());
         }
 
         // TEST END

--- a/src/main/java/us/thezircon/play/autopickup/utils/TallCrops.java
+++ b/src/main/java/us/thezircon/play/autopickup/utils/TallCrops.java
@@ -12,39 +12,23 @@ public class TallCrops {
     public ArrayList<Material> verticalReqDown = new ArrayList<>();
 
     public TallCrops () {
-        //verticalReqDown.add(Material.CAVE_VINES_PLANT);
-        //verticalReqDown.add(Material.CAVE_VINES);
-        //verticalReq.add(Material.SUGAR_CANE);
-        //verticalReq.add(Material.CACTUS);
-        //verticalReq.add(Material.KELP);
-        //verticalReq.add(Material.KELP_PLANT);
-
-        if (
+         if (
+                Bukkit.getVersion().contains("1.14") ||
+                Bukkit.getVersion().contains("1.15") ||
+                Bukkit.getVersion().contains("1.16") ||
                 Bukkit.getVersion().contains("1.17") ||
                 Bukkit.getVersion().contains("1.18") ||
                 Bukkit.getVersion().contains("1.19") ||
                 Bukkit.getVersion().contains("1.20") ||
                 Bukkit.getVersion().contains("1.21")
         ) {
-            verticalReqDown.add(Material.WEEPING_VINES_PLANT);
-            verticalReqDown.add(Material.WEEPING_VINES);
-            verticalReq.add(Material.TWISTING_VINES_PLANT);
-            verticalReq.add(Material.TWISTING_VINES);
+            verticalReq.add(Material.KELP);
+            verticalReq.add(Material.KELP_PLANT);
             verticalReq.add(Material.BAMBOO);
             verticalReq.add(Material.BAMBOO_SAPLING);
-        } else if (Bukkit.getVersion().contains("1.16")) {
-            verticalReqDown.add(Material.WEEPING_VINES);
-            verticalReqDown.add(Material.WEEPING_VINES_PLANT);
-            verticalReq.add(Material.TWISTING_VINES_PLANT);
-            verticalReq.add(Material.TWISTING_VINES);
-            verticalReq.add(Material.BAMBOO);
-            verticalReq.add(Material.BAMBOO_SAPLING);
-        } else if (
-                Bukkit.getVersion().contains("1.14") ||
-                Bukkit.getVersion().contains("1.15")
-        ) {
-            verticalReq.add(Material.BAMBOO);
-            verticalReq.add(Material.BAMBOO_SAPLING);
+        }else if(Bukkit.getVersion().contains("1.13")) {
+            verticalReq.add(Material.KELP);
+            verticalReq.add(Material.KELP_PLANT);
         }
     }
 

--- a/src/main/java/us/thezircon/play/autopickup/utils/TallCrops.java
+++ b/src/main/java/us/thezircon/play/autopickup/utils/TallCrops.java
@@ -4,6 +4,7 @@ import org.bukkit.Bukkit;
 import org.bukkit.Material;
 
 import java.util.ArrayList;
+import java.util.Objects;
 
 public class TallCrops {
 
@@ -11,6 +12,8 @@ public class TallCrops {
     public ArrayList<Material> verticalReqDown = new ArrayList<>();
 
     public TallCrops () {
+        //verticalReqDown.add(Material.CAVE_VINES_PLANT);
+        //verticalReqDown.add(Material.CAVE_VINES);
         //verticalReq.add(Material.SUGAR_CANE);
         //verticalReq.add(Material.CACTUS);
         //verticalReq.add(Material.KELP);
@@ -23,14 +26,12 @@ public class TallCrops {
                 Bukkit.getVersion().contains("1.20") ||
                 Bukkit.getVersion().contains("1.21")
         ) {
-            verticalReqDown.add(Material.WEEPING_VINES);
             verticalReqDown.add(Material.WEEPING_VINES_PLANT);
+            verticalReqDown.add(Material.WEEPING_VINES);
             verticalReq.add(Material.TWISTING_VINES_PLANT);
             verticalReq.add(Material.TWISTING_VINES);
             verticalReq.add(Material.BAMBOO);
             verticalReq.add(Material.BAMBOO_SAPLING);
-            verticalReq.add(Material.BIG_DRIPLEAF_STEM);
-            verticalReq.add(Material.BIG_DRIPLEAF);
         } else if (Bukkit.getVersion().contains("1.16")) {
             verticalReqDown.add(Material.WEEPING_VINES);
             verticalReqDown.add(Material.WEEPING_VINES_PLANT);
@@ -56,11 +57,6 @@ public class TallCrops {
     }
 
     public static Material checkAltType(Material material) {
-        if (Bukkit.getVersion().contains("1.17")) {
-            if (material.equals(Material.BIG_DRIPLEAF_STEM)) {
-                return Material.BIG_DRIPLEAF;
-            }
-        }
         return material;
     }
 }

--- a/src/main/java/us/thezircon/play/autopickup/utils/TallCrops.java
+++ b/src/main/java/us/thezircon/play/autopickup/utils/TallCrops.java
@@ -57,6 +57,18 @@ public class TallCrops {
     }
 
     public static Material checkAltType(Material material) {
+        if (
+                Bukkit.getVersion().contains("1.16") ||
+                        Bukkit.getVersion().contains("1.17") ||
+                        Bukkit.getVersion().contains("1.18") ||
+                        Bukkit.getVersion().contains("1.19") ||
+                        Bukkit.getVersion().contains("1.20") ||
+                        Bukkit.getVersion().contains("1.21")
+        ) {
+            if (material == Material.BAMBOO_SAPLING) {
+                return Material.BAMBOO;
+            }
+        }
         return material;
     }
 }

--- a/src/main/java/us/thezircon/play/autopickup/utils/TallCrops.java
+++ b/src/main/java/us/thezircon/play/autopickup/utils/TallCrops.java
@@ -16,16 +16,13 @@ public class TallCrops {
         //verticalReq.add(Material.KELP);
         //verticalReq.add(Material.KELP_PLANT);
 
-        if (Bukkit.getVersion().contains("1.18") || Bukkit.getVersion().contains("1.19")) {
-            verticalReqDown.add(Material.WEEPING_VINES);
-            verticalReqDown.add(Material.WEEPING_VINES_PLANT);
-            verticalReq.add(Material.TWISTING_VINES_PLANT);
-            verticalReq.add(Material.TWISTING_VINES);
-            verticalReq.add(Material.BAMBOO);
-            verticalReq.add(Material.BAMBOO_SAPLING);
-            verticalReq.add(Material.BIG_DRIPLEAF_STEM);
-            verticalReq.add(Material.BIG_DRIPLEAF);
-        } else if (Bukkit.getVersion().contains("1.17")) {
+        if (
+                Bukkit.getVersion().contains("1.17") ||
+                Bukkit.getVersion().contains("1.18") ||
+                Bukkit.getVersion().contains("1.19") ||
+                Bukkit.getVersion().contains("1.20") ||
+                Bukkit.getVersion().contains("1.21")
+        ) {
             verticalReqDown.add(Material.WEEPING_VINES);
             verticalReqDown.add(Material.WEEPING_VINES_PLANT);
             verticalReq.add(Material.TWISTING_VINES_PLANT);
@@ -41,10 +38,10 @@ public class TallCrops {
             verticalReq.add(Material.TWISTING_VINES);
             verticalReq.add(Material.BAMBOO);
             verticalReq.add(Material.BAMBOO_SAPLING);
-        } else if (Bukkit.getVersion().contains("1.15")) {
-            verticalReq.add(Material.BAMBOO);
-            verticalReq.add(Material.BAMBOO_SAPLING);
-        } else if (Bukkit.getVersion().contains("1.14")) {
+        } else if (
+                Bukkit.getVersion().contains("1.14") ||
+                Bukkit.getVersion().contains("1.15")
+        ) {
             verticalReq.add(Material.BAMBOO);
             verticalReq.add(Material.BAMBOO_SAPLING);
         }


### PR DESCRIPTION
This PR is about fixing some lines of code that didn't allow vertical breaking support for 1.20 and 1.21, add support to vertical breaking of glow berries & fix vertical breaking for big dripleafs

Code tested with Paper 1.21.4, Paper 1.17.1 & Paper 1.16.5 (Ensure code still works for 1.16.5 and below without any errors)