### PR TITLE
Change Modrinth upload action to mc-publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,13 +58,13 @@ jobs:
           cp "$JAR" "dist/AutoPickup-${{ env.VERSION }}.jar"
 
       - name: 📥 Upload to Modrinth
-        # Using the specific commit hash for v2.8.7 to ensure resolution
-        uses: modrinth/minotaur@d701509312117565922378f845d430030e46639d
+        # Using Kir-Antipov/mc-publish as recommended for non-Gradle GitHub Actions
+        uses: Kir-Antipov/mc-publish@v3
         with:
-          token: ${{ secrets.MODRINTH_TOKEN }}
-          project-id: "oB3hT7d7"
-          version-number: ${{ env.VERSION }}
-          version-name: "AutoPickup ${{ env.VERSION }}"
+          modrinth-token: ${{ secrets.MODRINTH_TOKEN }}
+          modrinth-id: "oB3hT7d7"
+          version: ${{ env.VERSION }}
+          name: "AutoPickup ${{ env.VERSION }}"
           version-type: "release"
           changelog: ${{ steps.changelog.outputs.changelog }}
           loaders: |


### PR DESCRIPTION
Updated the upload step to use Kir-Antipov/mc-publish for Modrinth.